### PR TITLE
Use winapi/kernel32 for Windows FFI

### DIFF
--- a/remutex/Cargo.toml
+++ b/remutex/Cargo.toml
@@ -5,3 +5,5 @@ version = "0.0.1"
 
 [dependencies]
 libc = "*"
+winapi = "0.1"
+kernel32-sys = "0.1"


### PR DESCRIPTION
Also adds `#[inline]` to all the methods because they're just thin wrappers anyway.
Blocked on landing new versions of `winapi` and `kernel32` on crates.io.