### PR TITLE
basic appveyor ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ Cargo.lock
 **/target/release
 /tmp.*
 **/*.h5
+
+# vim
+*~
+*.swp
+
+# vagrant
+.vagrant/
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ Thread-safe Rust bindings and high-level wrappers for the HDF5 library API.
 Note that this project is in its early development stage and hence things are likely to change
 and break on a regular basis.
 
+## Building
+
+### Windows
+
+Building hdf5-rs on Windows currently needs some manual preparation steps:
+
+* A HDF5 binary, namely the shared library `hdf5.dll` is needed for linking. For (currently) unknown reasons, the prebuilt binaries from [HDF-Group](http://www.hdfgroup.org/) do not work. It has to be build with gcc. Instructions for building HDF5 on Windows can be found [here](http://www.hdfgroup.org/HDF5/release/cmakebuild.html). For building the [TDM distribution](http://tdm-gcc.tdragon.net/)of MinGW-GCC is recommended, as it contains bintools for both 32bit & 64bit.
+
+* Set the environment variable `HDF5_LIBDIR` to point to the folder with the newly build `hdf5.dll`. Explanation: `pkg-config` will silently fail if not present and the path from the before-mentioned environment variable is added to the rustc commands by cargo. (Hint: Avoid path names with spaces, as they are difficult to escape correctly).
+
+* Run `cargo build` and/or `cargo test` to build and rust library and run the tests, repsectively. Hint: After changing the build environment, e.g. `HDF5_LIBDIR`, a `cargo clean` might be necessary.
+
+* Make sure `hdf5.dll` is on your search path, otherwise the tests will fail.
+
+
 ## License
 
 `hdf5-rs` is primarily distributed under the terms of both the MIT license and the

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and break on a regular basis.
 
 Building hdf5-rs on Windows currently needs some manual preparation steps:
 
-* A HDF5 binary, namely the shared library `hdf5.dll` is needed for linking. For (currently) unknown reasons, the prebuilt binaries from [HDF-Group](http://www.hdfgroup.org/) do not work. It has to be build with gcc. Instructions for building HDF5 on Windows can be found [here](http://www.hdfgroup.org/HDF5/release/cmakebuild.html). For building the [TDM distribution](http://tdm-gcc.tdragon.net/)of MinGW-GCC is recommended, as it contains bintools for both 32bit & 64bit.
+* A HDF5 binary, namely the shared library `hdf5.dll` is needed for linking. For (currently) unknown reasons, the prebuilt binaries from [HDF-Group](http://www.hdfgroup.org/) do not work (they are build with MSVC). It has to be build with gcc. Instructions for building HDF5 on Windows can be found [here](http://www.hdfgroup.org/HDF5/release/cmakebuild.html). For building the [TDM distribution](http://tdm-gcc.tdragon.net/) of MinGW-GCC is recommended, as it contains bintools for both 32bit & 64bit.
 
 * Set the environment variable `HDF5_LIBDIR` to point to the folder with the newly build `hdf5.dll`. Explanation: `pkg-config` will silently fail if not present and the path from the before-mentioned environment variable is added to the rustc commands by cargo. (Hint: Avoid path names with spaces, as they are difficult to escape correctly).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://img.shields.io/travis/aldanor/hdf5-rs.svg)](https://travis-ci.org/aldanor/hdf5-rs)
 
+[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/kxj3brxo8114nasb?svg=true)](https://ci.appveyor.com/project/kkirstein/hdf5-rs)
+
 Thread-safe Rust bindings and high-level wrappers for the HDF5 library API.
 
 Note that this project is in its early development stage and hence things are likely to change

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+# appveyor.yml
+# 
+# vim: sw=2 ts=2 et
+#
+
+version: 0.1.{build}
+
+environment:
+  RUST_TARGET: x86_64-pc-windows-gnu
+  #RUST_VERSION: 1.1.0
+  HDF5_LIBDIR: C:\hdf5_bin
+
+  matrix:
+    - RUST_VERSION: 1.1.0
+    - RUST_VERSION: nightly
+
+install:
+  # get rust & cargo
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:RUST_TARGET}.exe"
+  - rust-%RUST_VERSION%-%RUST_TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files\Rust-%RUST_VERSION%"
+  - set PATH=%PATH%;C:\Program Files\Rust-%RUST_VERSION%\bin
+
+  # get hdf5 binary (just get a prebuild binary for now)
+  - mkdir C:\hdf5_bin
+  - ps: Invoke-WebRequest "https://github.com/kkirstein/hdf5-rs/releases/download/alpha/hdf5.dll" -OutFile "C:\hdf5_bin\hdf5.dll"
+  - set PATH=C:\hdf5_bin;%PATH%
+
+  # output version info
+  - rustc --version
+  - cargo --version
+
+build: false
+
+test_script:
+  - cargo test --verbose
+

--- a/libhdf5-sys/src/h5p.rs
+++ b/libhdf5-sys/src/h5p.rs
@@ -111,7 +111,7 @@ extern {
     pub static H5P_LST_LINK_ACCESS_g: hid_t;
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 extern {
     // Property list classes (OSX version of the library)
     pub static H5P_CLS_ROOT_ID_g: hid_t;

--- a/remutex/src/windows.rs
+++ b/remutex/src/windows.rs
@@ -19,7 +19,10 @@ impl ReentrantMutex {
         mem::uninitialized()
     }
 
-    pub unsafe fn init(&mut self) -> ReentrantMutex {
+    //pub unsafe fn init(&mut self) -> ReentrantMutex {
+    //    ffi::InitializeCriticalSection(self.inner.get());
+    //}
+    pub unsafe fn init(&mut self) {
         ffi::InitializeCriticalSection(self.inner.get());
     }
 
@@ -42,7 +45,7 @@ impl ReentrantMutex {
 }
 
 mod ffi {
-    use libc::{LPVOID, LONG, HANDLE, c_ulong};
+    use libc::{LPVOID, LONG, HANDLE, c_ulong, BOOLEAN};
     pub type ULONG_PTR = c_ulong;
 
     #[repr(C)]

--- a/remutex/src/windows.rs
+++ b/remutex/src/windows.rs
@@ -15,17 +15,17 @@ unsafe impl Send for ReentrantMutex {}
 unsafe impl Sync for ReentrantMutex {}
 
 impl ReentrantMutex {
+    #[inline]
     pub unsafe fn uninitialized() -> ReentrantMutex {
         mem::uninitialized()
     }
 
-    //pub unsafe fn init(&mut self) -> ReentrantMutex {
-    //    ffi::InitializeCriticalSection(self.inner.get());
-    //}
+    #[inline]
     pub unsafe fn init(&mut self) {
         ffi::InitializeCriticalSection(self.inner.get());
     }
 
+    #[inline]
     pub unsafe fn lock(&self) {
         ffi::EnterCriticalSection(self.inner.get());
     }
@@ -35,10 +35,12 @@ impl ReentrantMutex {
         ffi::TryEnterCriticalSection(self.inner.get()) != 0
     }
 
+    #[inline]
     pub unsafe fn unlock(&self) {
         ffi::LeaveCriticalSection(self.inner.get());
     }
 
+    #[inline]
     pub unsafe fn destroy(&self) {
         ffi::DeleteCriticalSection(self.inner.get());
     }

--- a/remutex/src/windows.rs
+++ b/remutex/src/windows.rs
@@ -46,8 +46,10 @@ impl ReentrantMutex {
 
 mod ffi {
     use libc::{LPVOID, LONG, HANDLE, c_ulong, BOOLEAN};
+    #[allow(non_camel_case_types)]
     pub type ULONG_PTR = c_ulong;
 
+    #[allow(non_snake_case)]
     #[repr(C)]
     pub struct CRITICAL_SECTION {
         CriticalSectionDebug: LPVOID,

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -176,6 +176,41 @@ link_hid!(H5T_NATIVE_UINT_FAST64,      H5T_NATIVE_UINT_FAST64_g);
 #[cfg(target_os = "macos")] link_hid!(H5P_LST_LINK_CREATE_ID,      H5P_LST_LINK_CREATE_ID_g);
 #[cfg(target_os = "macos")] link_hid!(H5P_LST_LINK_ACCESS_ID,      H5P_LST_LINK_ACCESS_ID_g);
 
+// Property list classes (Windows version of the library)
+#[cfg(target_os = "windows")] link_hid!(H5P_ROOT,                    H5P_CLS_ROOT_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_OBJECT_CREATE,           H5P_CLS_OBJECT_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_FILE_CREATE,             H5P_CLS_FILE_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_FILE_ACCESS,             H5P_CLS_FILE_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_DATASET_CREATE,          H5P_CLS_DATASET_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_DATASET_ACCESS,          H5P_CLS_DATASET_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_DATASET_XFER,            H5P_CLS_DATASET_XFER_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_FILE_MOUNT,              H5P_CLS_FILE_MOUNT_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_GROUP_CREATE,            H5P_CLS_GROUP_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_GROUP_ACCESS,            H5P_CLS_GROUP_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_DATATYPE_CREATE,         H5P_CLS_DATATYPE_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_DATATYPE_ACCESS,         H5P_CLS_DATATYPE_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_STRING_CREATE,           H5P_CLS_STRING_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_ATTRIBUTE_CREATE,        H5P_CLS_ATTRIBUTE_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_OBJECT_COPY,             H5P_CLS_OBJECT_COPY_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LINK_CREATE,             H5P_CLS_LINK_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LINK_ACCESS,             H5P_CLS_LINK_ACCESS_ID_g);
+
+// Default property lists (Windows version of the library)
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_FILE_CREATE_ID,      H5P_LST_FILE_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_FILE_ACCESS_ID,      H5P_LST_FILE_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_DATASET_CREATE_ID,   H5P_LST_DATASET_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_DATASET_ACCESS_ID,   H5P_LST_DATASET_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_DATASET_XFER_ID,     H5P_LST_DATASET_XFER_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_FILE_MOUNT_ID,       H5P_LST_FILE_MOUNT_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_GROUP_CREATE_ID,     H5P_LST_GROUP_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_GROUP_ACCESS_ID,     H5P_LST_GROUP_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_DATATYPE_CREATE_ID,  H5P_LST_DATATYPE_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_DATATYPE_ACCESS_ID,  H5P_LST_DATATYPE_ACCESS_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_ATTRIBUTE_CREATE_ID, H5P_LST_ATTRIBUTE_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_OBJECT_COPY_ID,      H5P_LST_OBJECT_COPY_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_LINK_CREATE_ID,      H5P_LST_LINK_CREATE_ID_g);
+#[cfg(target_os = "windows")] link_hid!(H5P_LST_LINK_ACCESS_ID,      H5P_LST_LINK_ACCESS_ID_g);
+
 // Error class
 link_hid!(H5E_ERR_CLS,                 H5E_ERR_CLS_g);
 


### PR DESCRIPTION
This contains a basic appveyor integration:
- configuration is completely done with appveyor.yml (no GUI setup)
- a binary verson of hdf5.dll is downloaded from GitHub
- builds for rust 1.1 & nightly are checked

Todos:
- add build of hdf5 lib (needs cmake & MinGW)
- add 32bit build (?)
- add *-msvc target of rust

You have to setup a project on appveyor for your repo and change the link of the build status badge in Readme for this to work in your repo.