### PR TITLE
[WIP] feature flag to statically link hdf5 from conda binaries

### DIFF
--- a/hdf5-rs/Cargo.toml
+++ b/hdf5-rs/Cargo.toml
@@ -35,3 +35,7 @@ tempdir = "0.3"
 
 [build-dependencies]
 libhdf5-lib = { path = "../libhdf5-lib", version = "0.2.0" }
+
+[features]
+# Use static HDF5 libs downloaded from conda.
+conda = ["libhdf5-lib/conda"]

--- a/libhdf5-lib/Cargo.toml
+++ b/libhdf5-lib/Cargo.toml
@@ -10,5 +10,16 @@ homepage = "https://github.com/aldanor/hdf5-rs"
 description = "Build script support for the HDF5 library."
 edition = "2018"
 
+links = "hdf5"
+
 [build-dependencies]
 pkg-config = "0.3"
+rust-crypto = "0.2"
+curl = "*"
+bzip2 = "0.3.3"
+tar = "*"
+
+[features]
+# Use static HDF5 libs downloaded from conda.
+conda = []
+

--- a/libhdf5-lib/build.rs
+++ b/libhdf5-lib/build.rs
@@ -125,7 +125,7 @@ fn main() {
 }
 
 
-// Use `conda search --json --platform 'win-64' mkl-static`
+// Use `conda search --json --platform 'win-64' hdf5`
 // to query the metadata of conda package (includes MD5 sum).
 
 #[cfg(target_os = "linux")]
@@ -135,7 +135,10 @@ mod conda {
     pub const DLS: &[(&'static str, &'static str, &'static str)] = &[
         ("hdf5-1.10.4-hb1b8bf9_0.tar.bz2", 
          "https://repo.continuum.io/pkgs/main/linux-64/hdf5-1.10.4-hb1b8bf9_0.tar.bz2",
-         "e25e1d2af9836593f3678198b14816eb")
+         "e25e1d2af9836593f3678198b14816eb"),
+        ("zlib-1.2.11-hfbfcf68_1.tar.bz2", 
+         "https://repo.continuum.io/pkgs/main/linux-64/zlib-1.2.11-hfbfcf68_1.tar.bz2",
+         "cb3dfd6392fcc03474b8d71cf8f0b264")
     ];
 }
 
@@ -146,7 +149,10 @@ mod conda {
     pub const DLS: &[(&'static str, &'static str, &'static str)] = &[
         ("hdf5-1.8.20-hfa1e0ec_1.tar.bz2", 
          "https://repo.continuum.io/pkgs/main/osx-64/hdf5-1.8.20-hfa1e0ec_1.tar.bz2", 
-         "6b7457d9be3293d8ba73c36a0915d5f6")
+         "6b7457d9be3293d8ba73c36a0915d5f6"),
+        ("zlib-1.2.11-hf3cbc9b_2.tar.bz2",
+         "https://repo.continuum.io/pkgs/main/osx-64/zlib-1.2.11-hf3cbc9b_2.tar.bz2",
+         "f77c7d05dc47868e181135af65cb6e26")
     ];
 }
 
@@ -157,7 +163,10 @@ mod conda {
     pub const DLS: &[(&'static str, &'static str, &'static str)] = &[
         ("hdf5-1.8.16-vc14_0.tar.bz2", 
          "https://repo.continuum.io/pkgs/free/win-64/hdf5-1.8.16-vc14_0.tar.bz2", 
-         "c935a1d232cbe8fe09c1ffe0a64a322b")
+         "c935a1d232cbe8fe09c1ffe0a64a322b"),
+        ("zlib-1.2.11-vc14h1cdd9ab_1.tar.bz2", 
+         "https://repo.continuum.io/pkgs/main/win-64/zlib-1.2.11-vc14h1cdd9ab_1.tar.bz2",
+         "4e2394286375c49f880e159a7efae05f")
     ];
 }
 

--- a/libhdf5-lib/build.rs
+++ b/libhdf5-lib/build.rs
@@ -1,6 +1,14 @@
-use std::env;
-use std::fs;
-use std::path::PathBuf;
+use crypto::md5;
+use crypto::digest::Digest;
+
+use curl::easy::Easy;
+use bzip2::read::BzDecoder;
+use tar::Archive;
+
+use std::env::{self, var};
+use std::path::*;
+use std::fs::{self, File};
+use std::io::*;
 
 #[cfg(target_env = "msvc")]
 const IS_MSVC: bool = true;
@@ -100,12 +108,119 @@ fn find_hdf5_libs() -> (Vec<String>, Vec<String>) {
 }
 
 fn main() {
-    let (libs, dirs) = find_hdf5_libs();
+    conda_static();
+    return;
+    if var("CARGO_FEATURE_CONDA").is_ok() {
+        conda_static();
+    } else {
+        let (libs, dirs) = find_hdf5_libs();
 
-    for dir in dirs.iter() {
-        println!("cargo:rustc-link-search={}", dir);
+        for dir in dirs.iter() {
+            println!("cargo:rustc-link-search={}", dir);
+        }
+        for lib in libs.iter() {
+            println!("cargo:rustc-link-lib={}", lib);
+        }
     }
-    for lib in libs.iter() {
-        println!("cargo:rustc-link-lib={}", lib);
+}
+
+
+// Use `conda search --json --platform 'win-64' mkl-static`
+// to query the metadata of conda package (includes MD5 sum).
+
+#[cfg(target_os = "linux")]
+mod conda {
+    pub const LIB_PATH: &'static str = "lib";
+
+    pub const DLS: &[(&'static str, &'static str, &'static str)] = &[
+        ("hdf5-1.10.4-hb1b8bf9_0.tar.bz2", 
+         "https://repo.continuum.io/pkgs/main/linux-64/hdf5-1.10.4-hb1b8bf9_0.tar.bz2",
+         "e25e1d2af9836593f3678198b14816eb")
+    ];
+}
+
+#[cfg(target_os = "macos")]
+mod conda {
+    pub const LIB_PATH: &'static str = "lib";
+
+    pub const DLS: &[(&'static str, &'static str, &'static str)] = &[
+        ("hdf5-1.8.20-hfa1e0ec_1.tar.bz2", 
+         "https://repo.continuum.io/pkgs/main/osx-64/hdf5-1.8.20-hfa1e0ec_1.tar.bz2", 
+         "6b7457d9be3293d8ba73c36a0915d5f6")
+    ];
+}
+
+#[cfg(target_os = "windows")]
+mod conda {
+    pub const LIB_PATH: &'static str = "Library\\lib";
+
+    pub const DLS: &[(&'static str, &'static str, &'static str)] = &[
+        ("hdf5-1.8.16-vc14_0.tar.bz2", 
+         "https://repo.continuum.io/pkgs/free/win-64/hdf5-1.8.16-vc14_0.tar.bz2", 
+         "c935a1d232cbe8fe09c1ffe0a64a322b")
+    ];
+}
+
+fn download(uri: &str, filename: &str, out_dir: &Path) {
+
+    let out = PathBuf::from(out_dir.join(filename));
+
+    // Download the tarball.
+    let f = File::create(&out).unwrap();
+    let mut writer = BufWriter::new(f);
+    let mut easy = Easy::new();
+    easy.follow_location(true).unwrap();
+    easy.url(&uri).unwrap();
+    easy.write_function(move |data| {
+        Ok(writer.write(data).unwrap())
+    }).unwrap();
+    easy.perform().unwrap();
+
+    let response_code = easy.response_code().unwrap();
+    if response_code != 200 {
+        panic!("Unexpected response code {} for {}", response_code, uri);
     }
+}
+
+fn calc_md5(path: &Path) -> String {
+    let mut sum = md5::Md5::new();
+    let mut f = BufReader::new(fs::File::open(path).unwrap());
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf).unwrap();
+    sum.input(&buf);
+    sum.result_str()
+}
+
+fn extract<P: AsRef<Path>, P2: AsRef<Path>>(archive_path: P, extract_to: P2) {
+    let file = File::open(archive_path).unwrap();
+    let unzipped = BzDecoder::new(file);
+    let mut a = Archive::new(unzipped);
+    a.unpack(extract_to).unwrap();
+}
+
+fn conda_static() {
+    let out_dir = PathBuf::from(var("OUT_DIR").unwrap());
+
+    for (archive, uri, md5) in conda::DLS {
+        let archive_path = out_dir.join(archive);
+        if archive_path.exists() && calc_md5(&archive_path) == *md5 {
+            println!("Use existings archive");
+        } else {
+            println!("Download archive");
+            download(uri, archive, &out_dir);
+            extract(&archive_path, &out_dir);
+            
+            let sum = calc_md5(&archive_path);
+            if sum != *md5 {
+                panic!(
+                    "check sum of downloaded archive is incorrect: md5sum={}",
+                    sum
+                );
+            }
+        }
+    }
+    
+    println!("cargo:rustc-link-search={}", out_dir.join(conda::LIB_PATH).display());
+    println!("cargo:rustc-link-lib=static=hdf5");
+    println!("cargo:rustc-link-lib=static=z")
 }

--- a/libhdf5-lib/build.rs
+++ b/libhdf5-lib/build.rs
@@ -108,8 +108,7 @@ fn find_hdf5_libs() -> (Vec<String>, Vec<String>) {
 }
 
 fn main() {
-    conda_static();
-    return;
+
     if var("CARGO_FEATURE_CONDA").is_ok() {
         conda_static();
     } else {
@@ -207,6 +206,9 @@ fn extract<P: AsRef<Path>, P2: AsRef<Path>>(archive_path: P, extract_to: P2) {
     a.unpack(extract_to).unwrap();
 }
 
+
+/// Statically link to HDF5 binaries provided by conda
+/// TODO: detect what window runtime version is in use & select correct package?
 fn conda_static() {
     let out_dir = PathBuf::from(var("OUT_DIR").unwrap());
 

--- a/libhdf5-sys/Cargo.toml
+++ b/libhdf5-sys/Cargo.toml
@@ -16,3 +16,7 @@ libhdf5-lib = { path = "../libhdf5-lib", version = "0.2.0" }
 
 [build-dependencies]
 libhdf5-lib = { path = "../libhdf5-lib", version = "0.2.0" }
+
+[features]
+# Use static HDF5 libs downloaded from conda.
+conda = ["libhdf5-lib/conda"]


### PR DESCRIPTION
This is convenient way to quickly get static binaries, without having to think about where HDF5 is coming from & how to deploy the dll/so/dylibs.  

A better name for the feature is possibly 'conda-static'?  Wondering what people think about an option like this. 

I'm also doing something similar here:
https://github.com/pmarks/rust-intel-mkl/blob/master/build.rs
which is working nicely. Originally modeled on the tensorflow bindings:
https://github.com/tensorflow/rust/blob/master/tensorflow-sys/build.rs

TODO:
- [ ] test the `conda` feature in Travis