### PR TITLE
Some fixes for slice API

### DIFF
--- a/hdf5-rs/src/hl/container.rs
+++ b/hdf5-rs/src/hl/container.rs
@@ -60,10 +60,9 @@ impl<'a> Reader<'a> {
     /// the slice, after singleton dimensions are dropped. 
     /// Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn read_slice<T, S, D>(&self, slice: &SliceInfo<S, D>) -> Result<Array<T, D>>
+    pub fn read_slice<T, D>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array<T, D>>
     where
         T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         ensure!(!self.obj.is_attr(), "slicing cannot be used on attribute datasets");
@@ -163,10 +162,9 @@ impl<'a> Reader<'a> {
     /// Reads the given `slice` of the dataset into a 1-dimensional array.
     ///
     /// The dataset must be 1-dimensional.
-    pub fn read_slice_1d<T, S>(&self, slice: &SliceInfo<S, Ix1>) -> Result<Array1<T>>
+    pub fn read_slice_1d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array1<T>>
     where
         T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
     {
         self.read_slice(slice)
     }
@@ -181,10 +179,9 @@ impl<'a> Reader<'a> {
     /// Reads the given `slice` of the dataset into a 2-dimensional array.
     ///
     /// The dataset must be 2-dimensional.
-    pub fn read_slice_2d<T, S>(&self, slice: &SliceInfo<S, Ix2>) -> Result<Array2<T>>
+    pub fn read_slice_2d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array2<T>>
     where
         T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
     {
         self.read_slice(slice)
     }
@@ -253,11 +250,10 @@ impl<'a> Writer<'a> {
     /// If the array has a fixed number of dimensions, it must match the dimensionality of
     /// dataset. Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn write_slice<'b, A, T, S, D>(&self, arr: A, slice: &SliceInfo<S, D>) -> Result<()>
+    pub fn write_slice<'b, A, T, D>(&self, arr: A, slice: &AsRef<[SliceOrIndex]>) -> Result<()>
     where
         A: Into<ArrayView<'b, T, D>>,
         T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         ensure!(!self.obj.is_attr(), "slicing cannot be used on attribute datasets");
@@ -500,10 +496,9 @@ impl Container {
     /// Reads the given `slice` of the dataset into a 1-dimensional array.
     ///
     /// The dataset must be 1-dimensional.
-    pub fn read_slice_1d<T, S>(&self, slice: &SliceInfo<S, Ix1>) -> Result<Array1<T>>
+    pub fn read_slice_1d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array1<T>>
     where
-        T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
+        T: H5Type
     {
         self.as_reader().read_slice_1d(slice)
     }
@@ -518,10 +513,9 @@ impl Container {
     /// Reads the given `slice` of the dataset into a 2-dimensional array.
     ///
     /// The dataset must be 2-dimensional.
-    pub fn read_slice_2d<T, S>(&self, slice: &SliceInfo<S, Ix2>) -> Result<Array2<T>>
+    pub fn read_slice_2d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array2<T>>
     where
-        T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
+        T: H5Type
     {
         self.as_reader().read_slice_2d(slice)
     }
@@ -536,10 +530,9 @@ impl Container {
     /// the slice, after singleton dimensions are dropped. 
     /// Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn read_slice<T, S, D>(&self, slice: &SliceInfo<S, D>) -> Result<Array<T, D>>
+    pub fn read_slice<T, D>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array<T, D>>
     where
         T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         self.as_reader().read_slice(slice)
@@ -581,11 +574,10 @@ impl Container {
     /// If the array has a fixed number of dimensions, it must match the dimensionality of
     /// dataset. Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn write_slice<'b, A, T, S, D>(&self, arr: A, slice: &SliceInfo<S, D>) -> Result<()>
+    pub fn write_slice<'b, A, T, D>(&self, arr: A, slice: &AsRef<[SliceOrIndex]>) -> Result<()>
     where
         A: Into<ArrayView<'b, T, D>>,
         T: H5Type,
-        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         self.as_writer().write_slice(arr, slice)

--- a/hdf5-rs/src/hl/container.rs
+++ b/hdf5-rs/src/hl/container.rs
@@ -60,9 +60,10 @@ impl<'a> Reader<'a> {
     /// the slice, after singleton dimensions are dropped. 
     /// Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn read_slice<T, D>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array<T, D>>
+    pub fn read_slice<T, S, D>(&self, slice: &SliceInfo<S, D>) -> Result<Array<T, D>>
     where
         T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         ensure!(!self.obj.is_attr(), "slicing cannot be used on attribute datasets");
@@ -160,11 +161,11 @@ impl<'a> Reader<'a> {
     }
 
     /// Reads the given `slice` of the dataset into a 1-dimensional array.
-    ///
-    /// The dataset must be 1-dimensional.
-    pub fn read_slice_1d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array1<T>>
+    /// The slice must yield a 1-dimensional result.
+    pub fn read_slice_1d<T, S>(&self, slice: &SliceInfo<S, ndarray::Ix1>) -> Result<Array1<T>>
     where
         T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
     {
         self.read_slice(slice)
     }
@@ -176,12 +177,13 @@ impl<'a> Reader<'a> {
         self.read()
     }
 
+
     /// Reads the given `slice` of the dataset into a 2-dimensional array.
-    ///
-    /// The dataset must be 2-dimensional.
-    pub fn read_slice_2d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array2<T>>
+    /// The slice must yield a 2-dimensional result.
+    pub fn read_slice_2d<T, S>(&self, slice: &SliceInfo<S, ndarray::Ix2>) -> Result<Array2<T>>
     where
         T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
     {
         self.read_slice(slice)
     }
@@ -250,10 +252,11 @@ impl<'a> Writer<'a> {
     /// If the array has a fixed number of dimensions, it must match the dimensionality of
     /// dataset. Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn write_slice<'b, A, T, D>(&self, arr: A, slice: &AsRef<[SliceOrIndex]>) -> Result<()>
+    pub fn write_slice<'b, A, T, S, D>(&self, arr: A, slice: &SliceInfo<S, D>) -> Result<()>
     where
         A: Into<ArrayView<'b, T, D>>,
         T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         ensure!(!self.obj.is_attr(), "slicing cannot be used on attribute datasets");
@@ -494,11 +497,11 @@ impl Container {
     }
 
     /// Reads the given `slice` of the dataset into a 1-dimensional array.
-    ///
-    /// The dataset must be 1-dimensional.
-    pub fn read_slice_1d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array1<T>>
+    /// The slice must yield a 1-dimensional result.
+    pub fn read_slice_1d<T, S>(&self, slice: &SliceInfo<S, ndarray::Ix1>) -> Result<Array1<T>>
     where
-        T: H5Type
+        T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
     {
         self.as_reader().read_slice_1d(slice)
     }
@@ -510,12 +513,12 @@ impl Container {
         self.as_reader().read_2d()
     }
 
-    /// Reads the given `slice` of the dataset into a 2-dimensional array.
-    ///
-    /// The dataset must be 2-dimensional.
-    pub fn read_slice_2d<T>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array2<T>>
+    /// Reads the given `slice` of the dataset into a 1-dimensional array.
+    /// The slice must yield a 2-dimensional result.
+    pub fn read_slice_2d<T, S>(&self, slice: &SliceInfo<S, ndarray::Ix2>) -> Result<Array2<T>>
     where
-        T: H5Type
+        T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
     {
         self.as_reader().read_slice_2d(slice)
     }
@@ -530,9 +533,10 @@ impl Container {
     /// the slice, after singleton dimensions are dropped. 
     /// Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn read_slice<T, D>(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Array<T, D>>
+    pub fn read_slice<T, S, D>(&self, slice: &SliceInfo<S, D>) -> Result<Array<T, D>>
     where
         T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         self.as_reader().read_slice(slice)
@@ -574,10 +578,11 @@ impl Container {
     /// If the array has a fixed number of dimensions, it must match the dimensionality of
     /// dataset. Use the multi-dimensional slice macro `s![]` from `ndarray` to conveniently create
     /// a multidimensional slice.
-    pub fn write_slice<'b, A, T, D>(&self, arr: A, slice: &AsRef<[SliceOrIndex]>) -> Result<()>
+    pub fn write_slice<'b, A, T, S, D>(&self, arr: A, slice: &SliceInfo<S, D>) -> Result<()>
     where
         A: Into<ArrayView<'b, T, D>>,
         T: H5Type,
+        S: AsRef<[SliceOrIndex]>,
         D: ndarray::Dimension,
     {
         self.as_writer().write_slice(arr, slice)

--- a/hdf5-rs/src/hl/space.rs
+++ b/hdf5-rs/src/hl/space.rs
@@ -56,10 +56,7 @@ impl Dataspace {
     /// Select a slice (known as a 'hyperslab' in HDF5 terminology) of the Dataspace.
     /// Returns the shape of array that is capable of holding the resulting slice.
     /// Useful when you want to read a subset of a dataset.
-    pub fn select_slice<T, D>(&self, slice: &SliceInfo<T, D>) -> Result<Vec<Ix>>
-    where
-        T: AsRef<[SliceOrIndex]>,
-        D: ndarray::Dimension,
+    pub fn select_slice(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Vec<Ix>>
     {
         let shape = self.dims();
         let ss: &[SliceOrIndex] = slice.as_ref();

--- a/hdf5-rs/src/hl/space.rs
+++ b/hdf5-rs/src/hl/space.rs
@@ -56,7 +56,8 @@ impl Dataspace {
     /// Select a slice (known as a 'hyperslab' in HDF5 terminology) of the Dataspace.
     /// Returns the shape of array that is capable of holding the resulting slice.
     /// Useful when you want to read a subset of a dataset.
-    pub fn select_slice(&self, slice: &AsRef<[SliceOrIndex]>) -> Result<Vec<Ix>>
+    pub fn select_slice<S>(&self, slice: S) -> Result<Vec<Ix>>
+    where S: AsRef<[SliceOrIndex]>
     {
         let shape = self.dims();
         let ss: &[SliceOrIndex] = slice.as_ref();


### PR DESCRIPTION
@aldanor  Thanks for reviewing this. I think I've fixed all the issues raised in #26 :

> 1. First I've tried `pixels.read_slice_1d::<Pixel>(s![.., 1])`, which failed to compile:
>    ```
>    no method named `read_slice_1d` found for type `h5::hl::dataset::Dataset`
>    ```

Added these methods to Dataset.

>    Slicing API should really be accessible directly from datasets; but that we can fix pretty easily.
> 2. Ok, next try: `pixels.as_reader().read_slice_1d::<Pixel>(s![.., 1])`, also fails to compile:
>    ```
>    wrong number of type arguments: expected 2, found 1
>    ```
>    Now this one's not very nice, having to provide a `_` placeholder for a second type is counter-intuitive and may lead to problems with type inference.

Here's the `ndarray` slice method: https://docs.rs/ndarray/0.12.1/ndarray/struct.ArrayBase.html#method.slice.  They get around having the `S` type because they know `D` (the dimensionality of the input array), and `Do`, the dimensionality of the output of the slice.  This won't work for us.  What does work is to pass the slice as a trait object `&AsRef<[SliceOrIndex]>`.  This causes ~2 new virtual calls. Given that we're going to be calling into HDF5 multiple times to carry out this read/write, I'd be shocked if this had a noticeable perf impact.

> 3. Next one... `pixels.as_reader().read_slice_1d::<Pixel, _>(s![.., 1])`... it now compiles but fails at runtime:
>    ```
>    Error: ndim mismatch: expected 1, got 2
>    ```
>    This one's actually strange. Looking up docstring for `read_slice_1d()`, we see "Reads the given slice of the dataset into a 1-dimensional array. The dataset must be 1-dimensional". Now, why does the dataset have to be 1-dimensional? I'm reading a column of a matrix here, what's wrong with that?..

The dimension checks were not correct. They're fixed here. The *output* dimension of the slice needs to match the D::NDIM, which can be smaller than the dimensionality of the Dataset

>    More placeholders...
> 5. Fixed: `pixels.as_reader().read_slice::<Pixel, _, _>(s![.., 1])`.. compiles but:
>    ```
>    Error: ndim mismatch: expected 1, got 2
>    ```
Fixed - same problem as 3.